### PR TITLE
chore(release): release-plz update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "outlook-mapi-sys"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "outlook-mapi-stub",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ categories = [ "os::windows-apis" ]
 
 [workspace.dependencies]
 outlook-mapi-stub = "0.3.0"
-outlook-mapi-sys = { version = "0.6.0", default-features = false }
+outlook-mapi-sys = { version = "0.6.1", default-features = false }
 
 cmake = "0.1"
 proc-macro2 = "1.0"

--- a/crates/mapi-sys/CHANGELOG.md
+++ b/crates/mapi-sys/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/wravery/outlook-mapi-rs/compare/outlook-mapi-sys-v0.6.0...outlook-mapi-sys-v0.6.1) - 2024-09-19
+
+### Other
+- *(deps)* pick up latest changes in MAPIStubLibrary
+
 ## [0.6.0](https://github.com/microsoft/mapi-rs/compare/outlook-mapi-sys-v0.5.7...outlook-mapi-sys-v0.6.0) - 2024-09-05
 
 ### Other

--- a/crates/mapi-sys/Cargo.toml
+++ b/crates/mapi-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "outlook-mapi-sys"
-version = "0.6.0"
+version = "0.6.1"
 description = "Bindings generated with the windows crate for the Outlook MAPI interface"
 
 authors.workspace = true


### PR DESCRIPTION
Manually running `release-plz update` offline since the GH Actions bot does not have the necessary permissions to create a PR.