### PR TITLE
Support Office installations without requiring Outlook for MAPI detection

### DIFF
--- a/crates/mapi-sys/Cargo.toml
+++ b/crates/mapi-sys/Cargo.toml
@@ -22,7 +22,6 @@ targets = [
 default = [ "olmapi32" ]
 olmapi32 = [
     "windows/Win32_System_ApplicationInstallationAndServicing",
-    "windows/Win32_System_Registry",
 ]
 
 [dependencies]

--- a/crates/mapi-sys/Cargo.toml
+++ b/crates/mapi-sys/Cargo.toml
@@ -22,6 +22,7 @@ targets = [
 default = [ "olmapi32" ]
 olmapi32 = [
     "windows/Win32_System_ApplicationInstallationAndServicing",
+    "windows/Win32_Storage_FileSystem",
 ]
 
 [dependencies]

--- a/crates/mapi-sys/src/installation.rs
+++ b/crates/mapi-sys/src/installation.rs
@@ -4,7 +4,7 @@ use windows_core::{PCWSTR, w};
 
 use crate::load_mapi::{
     OFFICE_QUALIFIERS, OUTLOOK_QUALIFIED_COMPONENTS, get_office_executable_path,
-    get_outlook_mapi_path,
+    get_office_mapi_path_no_install, get_outlook_mapi_path,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -14,7 +14,7 @@ pub enum Architecture {
 }
 
 pub enum InstallationState {
-    Installed(Architecture, PathBuf),
+    Installed(Architecture, PathBuf, bool),
     NotInstalled,
 }
 
@@ -44,9 +44,9 @@ fn try_office_installation(category: PCWSTR, qualifier: PCWSTR) -> Option<Instal
     let actual_arch = get_binary_architecture(&exe_path).ok()?;
 
     // Get the corresponding MAPI DLL path
-    let dll_path = unsafe { get_outlook_mapi_path(category, qualifier) }.ok()?;
+    let dll_path = unsafe { get_office_mapi_path_no_install(category, qualifier) }.ok()?;
 
-    Some(InstallationState::Installed(actual_arch, dll_path))
+    Some(InstallationState::Installed(actual_arch, dll_path, false))
 }
 
 pub fn check_outlook_mapi_installation() -> InstallationState {
@@ -59,7 +59,7 @@ pub fn check_outlook_mapi_installation() -> InstallationState {
     for category in OUTLOOK_QUALIFIED_COMPONENTS {
         for (bitness, qualifier) in OUTLOOK_QUALIFIERS {
             if let Ok(path) = unsafe { get_outlook_mapi_path(category, qualifier) } {
-                return InstallationState::Installed(bitness, path);
+                return InstallationState::Installed(bitness, path, true);
             }
         }
     }

--- a/crates/mapi-sys/src/installation.rs
+++ b/crates/mapi-sys/src/installation.rs
@@ -1,6 +1,11 @@
 use std::path::PathBuf;
+use windows::Win32::Storage::FileSystem::GetBinaryTypeW;
+use windows_core::{PCWSTR, w};
 
-use crate::load_mapi::{OFFICE_QUALIFIERS, OUTLOOK_QUALIFIED_COMPONENTS, get_outlook_mapi_path};
+use crate::load_mapi::{
+    OFFICE_QUALIFIERS, OUTLOOK_QUALIFIED_COMPONENTS, get_office_executable_path,
+    get_outlook_mapi_path,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Architecture {
@@ -13,11 +18,57 @@ pub enum InstallationState {
     NotInstalled,
 }
 
+fn get_binary_architecture(
+    file_path: &PathBuf,
+) -> Result<Architecture, Box<dyn std::error::Error>> {
+    let path_str = file_path.to_string_lossy();
+    let path_wide: Vec<u16> = path_str.encode_utf16().chain(std::iter::once(0)).collect();
+    let mut binary_type: u32 = 0;
+
+    unsafe {
+        GetBinaryTypeW(PCWSTR::from_raw(path_wide.as_ptr()), &mut binary_type)?;
+
+        match binary_type {
+            0 => Ok(Architecture::X86), // SCS_32BIT_BINARY
+            6 => Ok(Architecture::X64), // SCS_64BIT_BINARY
+            _ => Err(format!("Unsupported binary type: {}", binary_type).into()),
+        }
+    }
+}
+
+fn try_office_installation(category: PCWSTR, qualifier: PCWSTR) -> Option<InstallationState> {
+    // Try to get the executable path for architecture detection
+    let exe_path = unsafe { get_office_executable_path(category, qualifier) }.ok()?;
+
+    // Detect architecture from the executable
+    let actual_arch = get_binary_architecture(&exe_path).ok()?;
+
+    // Get the corresponding MAPI DLL path
+    let dll_path = unsafe { get_outlook_mapi_path(category, qualifier) }.ok()?;
+
+    Some(InstallationState::Installed(actual_arch, dll_path))
+}
+
 pub fn check_outlook_mapi_installation() -> InstallationState {
+    const OUTLOOK_QUALIFIERS: [(Architecture, PCWSTR); 2] = [
+        (Architecture::X64, w!("outlook.x64.exe")),
+        (Architecture::X86, w!("outlook.exe")),
+    ];
+
+    // First, try the standard Outlook qualified components
     for category in OUTLOOK_QUALIFIED_COMPONENTS {
-        for (arch, qualifier) in OFFICE_QUALIFIERS {
+        for (bitness, qualifier) in OUTLOOK_QUALIFIERS {
             if let Ok(path) = unsafe { get_outlook_mapi_path(category, qualifier) } {
-                return InstallationState::Installed(arch, path);
+                return InstallationState::Installed(bitness, path);
+            }
+        }
+    }
+
+    // If not found, try the fallback Office qualifiers
+    for category in OUTLOOK_QUALIFIED_COMPONENTS {
+        for qualifier in OFFICE_QUALIFIERS {
+            if let Some(installation) = try_office_installation(category, qualifier) {
+                return installation;
             }
         }
     }

--- a/crates/mapi-sys/src/installation.rs
+++ b/crates/mapi-sys/src/installation.rs
@@ -1,9 +1,6 @@
 use std::path::PathBuf;
 
-use windows::Win32::System::Registry::*;
-use windows_core::{HSTRING, PCWSTR, w};
-
-use crate::load_mapi::{OUTLOOK_QUALIFIED_COMPONENTS, get_outlook_mapi_path};
+use crate::load_mapi::{OFFICE_QUALIFIERS, OUTLOOK_QUALIFIED_COMPONENTS, get_outlook_mapi_path};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Architecture {
@@ -11,228 +8,19 @@ pub enum Architecture {
     X86,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum DetectionMethod {
-    /// Found via Outlook-specific Windows Installer API (legacy method)
-    OutlookInstaller,
-    /// Found via Office ClickToRun registry detection
-    OfficeClickToRun,
-    /// Found via Office MSI registry detection  
-    OfficeMsi,
-}
-
 pub enum InstallationState {
-    Installed(Architecture, PathBuf, DetectionMethod),
+    Installed(Architecture, PathBuf),
     NotInstalled,
 }
 
-#[derive(Debug, Clone)]
-pub struct OfficeInstallation {
-    pub architecture: Architecture,
-    pub version: String,
-    pub install_path: PathBuf,
-    pub mapi_dll_path: PathBuf,
-    pub detection_method: DetectionMethod,
-}
-
-// Registry paths for Office installations
-// Only checking Office 16.0+ as earlier versions don't have the MAPI support we need
-const OFFICE_REGISTRY_PATHS: &[&str] = &[
-    r"SOFTWARE\Microsoft\Office\ClickToRun\Configuration", // Modern Office 365/2016+
-    r"SOFTWARE\Microsoft\Office\16.0\Common\InstallRoot",  // Traditional MSI Office 2016
-];
-
 pub fn check_outlook_mapi_installation() -> InstallationState {
-    // First try the original Outlook-specific method for backward compatibility
-    if let InstallationState::Installed(arch, path, detection_method) =
-        check_outlook_installation_legacy()
-    {
-        return InstallationState::Installed(arch, path, detection_method);
-    }
-
-    // Then check for Office installations via registry
-    if let Some(installation) = find_office_installations().into_iter().next() {
-        return InstallationState::Installed(
-            installation.architecture,
-            installation.mapi_dll_path,
-            installation.detection_method,
-        );
-    }
-
-    InstallationState::NotInstalled
-}
-
-/// Legacy method using Windows Installer API to find Outlook installations
-fn check_outlook_installation_legacy() -> InstallationState {
-    const OUTLOOK_QUALIFIERS: [(Architecture, PCWSTR); 2] = [
-        (Architecture::X64, w!("outlook.x64.exe")),
-        (Architecture::X86, w!("outlook.exe")),
-    ];
-
     for category in OUTLOOK_QUALIFIED_COMPONENTS {
-        for (bitness, qualifier) in OUTLOOK_QUALIFIERS {
+        for (arch, qualifier) in OFFICE_QUALIFIERS {
             if let Ok(path) = unsafe { get_outlook_mapi_path(category, qualifier) } {
-                return InstallationState::Installed(
-                    bitness,
-                    path,
-                    DetectionMethod::OutlookInstaller,
-                );
+                return InstallationState::Installed(arch, path);
             }
         }
     }
 
     InstallationState::NotInstalled
-}
-
-/// Find all Office installations that include MAPI support
-pub fn find_office_installations() -> Vec<OfficeInstallation> {
-    let mut installations = Vec::new();
-
-    // Check both 64-bit and 32-bit registry views
-    for &wow64_flag in &[KEY_WOW64_64KEY, KEY_WOW64_32KEY] {
-        let arch = if wow64_flag == KEY_WOW64_64KEY {
-            Architecture::X64
-        } else {
-            Architecture::X86
-        };
-
-        installations.extend(check_office_registry_paths(arch, wow64_flag));
-    }
-
-    // Remove duplicates and sort by version (newest first)
-    installations.sort_by(|a, b| b.version.cmp(&a.version));
-    installations.dedup_by(|a, b| a.install_path == b.install_path);
-
-    installations
-}
-
-fn check_office_registry_paths(
-    arch: Architecture,
-    wow64_flag: REG_SAM_FLAGS,
-) -> Vec<OfficeInstallation> {
-    let mut installations = Vec::new();
-
-    for &registry_path in OFFICE_REGISTRY_PATHS {
-        if let Some(installation) = check_office_registry_path(registry_path, arch, wow64_flag) {
-            installations.push(installation);
-        }
-    }
-
-    installations
-}
-
-fn check_office_registry_path(
-    registry_path: &str,
-    arch: Architecture,
-    wow64_flag: REG_SAM_FLAGS,
-) -> Option<OfficeInstallation> {
-    unsafe {
-        let mut hkey = HKEY::default();
-        let path_hstring = HSTRING::from(registry_path);
-
-        if RegOpenKeyExW(
-            HKEY_LOCAL_MACHINE,
-            &path_hstring,
-            Some(0),
-            KEY_READ | wow64_flag,
-            &mut hkey,
-        )
-        .is_ok()
-        {
-            // Try to get the install path - different key names for different registry paths
-            let install_path = if registry_path.contains("ClickToRun") {
-                // For ClickToRun installations, get InstallationPath and construct root\Office16 path
-                if let Some(base_path) = read_registry_string(&hkey, w!("InstallationPath")) {
-                    let mut office_path = PathBuf::from(base_path);
-                    office_path.push("root");
-                    office_path.push("Office16");
-                    Some(office_path)
-                } else {
-                    None
-                }
-            } else {
-                // For traditional MSI installations, use the Path key directly
-                read_registry_string(&hkey, w!("Path")).map(PathBuf::from)
-            };
-
-            if let Some(install_path) = install_path {
-                // Check for MAPI DLL in the installation
-                let mapi_paths = [
-                    install_path.join("olmapi32.dll"),
-                    install_path.join("mapi32.dll"),
-                ];
-
-                for mapi_path in &mapi_paths {
-                    if mapi_path.exists() {
-                        let version = extract_version_from_path(registry_path);
-                        let detection_method = if registry_path.contains("ClickToRun") {
-                            DetectionMethod::OfficeClickToRun
-                        } else {
-                            DetectionMethod::OfficeMsi
-                        };
-                        let _ = RegCloseKey(hkey);
-                        return Some(OfficeInstallation {
-                            architecture: arch,
-                            version,
-                            install_path: install_path.clone(),
-                            mapi_dll_path: mapi_path.clone(),
-                            detection_method,
-                        });
-                    }
-                }
-            }
-
-            let _ = RegCloseKey(hkey);
-        }
-    }
-
-    None
-}
-
-fn read_registry_string(hkey: &HKEY, value_name: PCWSTR) -> Option<String> {
-    unsafe {
-        let mut buffer_size = 0u32;
-
-        // Get the required buffer size
-        if RegQueryValueExW(*hkey, value_name, None, None, None, Some(&mut buffer_size)).is_ok()
-            && buffer_size > 0
-        {
-            let mut buffer = vec![0u16; (buffer_size / 2) as usize];
-            let mut actual_size = buffer_size;
-
-            if RegQueryValueExW(
-                *hkey,
-                value_name,
-                None,
-                None,
-                Some(buffer.as_mut_ptr() as *mut u8),
-                Some(&mut actual_size),
-            )
-            .is_ok()
-            {
-                // Remove null terminator and convert to String
-                if let Some(null_pos) = buffer.iter().position(|&x| x == 0) {
-                    buffer.truncate(null_pos);
-                }
-                return String::from_utf16(&buffer).ok();
-            }
-        }
-    }
-
-    None
-}
-
-fn extract_version_from_path(registry_path: &str) -> String {
-    // Extract version info from registry path
-    if registry_path.contains("ClickToRun") {
-        "16.0-ClickToRun".to_string()
-    } else if let Some(start) = registry_path.find(r"\Office\") {
-        let version_start = start + 8; // Length of "\Office\"
-        if let Some(end) = registry_path[version_start..].find('\\') {
-            return registry_path[version_start..version_start + end].to_string();
-        }
-        "16.0-MSI".to_string()
-    } else {
-        "Unknown".to_string()
-    }
 }

--- a/crates/mapi-sys/src/load_mapi.rs
+++ b/crates/mapi-sys/src/load_mapi.rs
@@ -1,6 +1,28 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+//! MAPI Library Loading and Office Detection
+//!
+//! This module provides functionality to detect and load MAPI (Messaging Application
+//! Programming Interface) libraries from Microsoft Office installations.
+//!
+//! # Official Support
+//!
+//! Microsoft officially supports MAPI through proper Office installations that include
+//! MAPI components. Modern Office installations can include MAPI without requiring Outlook.
+//!
+//! # Experimental Fallback Support
+//!
+//! This module also includes **experimental** fallback detection for Office
+//! applications that may have MAPI components available. This functionality:
+//!
+//! - Is **NOT officially supported** by Microsoft
+//! - May not work reliably across all Office configurations  
+//! - May break in future Office updates without notice
+//! - Should be considered a temporary workaround
+//!
+//! **This fallback approach is experimental while we develop a more robust long-term solution.**
+
 use std::{iter, path::PathBuf};
 use windows::Win32::{
     Foundation::*,
@@ -10,7 +32,15 @@ use windows_core::*;
 
 const OLMAPI32_MODULE: PCWSTR = w!("olmapi32.dll");
 
-// Office application fallback qualifiers for MAPI detection
+// EXPERIMENTAL: Office application fallback qualifiers for MAPI detection
+//
+// WARNING: This fallback detection method is NOT officially supported by Microsoft.
+// While Office applications may share MAPI infrastructure with Outlook, this behavior
+// is not guaranteed and may change in future Office versions without notice.
+//
+// This experimental approach is provided as a temporary workaround for environments
+// where standard MAPI detection fails but other Office applications are installed.
+// We are actively working on a more robust long-term solution for MAPI detection.
 pub const OFFICE_QUALIFIERS: [PCWSTR; 6] = [
     // Excel
     w!("excel.exe"),
@@ -149,6 +179,11 @@ pub fn ensure_olmapi32() -> Result<HMODULE> {
         }
 
         // Try fallback Office app qualifiers (without installation)
+        //
+        // EXPERIMENTAL FALLBACK: Attempt to locate MAPI through other Office applications.
+        // This is NOT officially supported.
+        // We are working on a more robust long-term solution for comprehensive MAPI detection.
+        // This behavior may break in future Office updates without notice.
         for category in OUTLOOK_QUALIFIED_COMPONENTS {
             for qualifier in OFFICE_QUALIFIERS {
                 if let Ok(path) = get_office_mapi_path_no_install(category, qualifier) {

--- a/crates/mapi-sys/src/load_mapi.rs
+++ b/crates/mapi-sys/src/load_mapi.rs
@@ -75,17 +75,12 @@ pub fn ensure_olmapi32() -> Result<HMODULE> {
         }
 
         // Use our new installation detection to find Office/MAPI installations
-        use crate::installation::{check_outlook_mapi_installation, InstallationState};
-        
+        use crate::installation::{InstallationState, check_outlook_mapi_installation};
+
         match check_outlook_mapi_installation() {
             InstallationState::Installed(_, dll_path, _) => {
-                let path_str = dll_path
-                    .to_str()
-                    .ok_or_else(|| Error::from(E_INVALIDARG))?;
-                let buffer: Vec<_> = path_str
-                    .encode_utf16()
-                    .chain(iter::once(0))
-                    .collect();
+                let path_str = dll_path.to_str().ok_or_else(|| Error::from(E_INVALIDARG))?;
+                let buffer: Vec<_> = path_str.encode_utf16().chain(iter::once(0)).collect();
                 return LoadLibraryW(PCWSTR::from_raw(buffer.as_ptr()));
             }
             InstallationState::NotInstalled => {

--- a/crates/mapi-sys/src/load_mapi.rs
+++ b/crates/mapi-sys/src/load_mapi.rs
@@ -78,7 +78,7 @@ pub fn ensure_olmapi32() -> Result<HMODULE> {
         use crate::installation::{check_outlook_mapi_installation, InstallationState};
         
         match check_outlook_mapi_installation() {
-            InstallationState::Installed(_, dll_path) => {
+            InstallationState::Installed(_, dll_path, _) => {
                 let path_str = dll_path
                     .to_str()
                     .ok_or_else(|| Error::from(E_INVALIDARG))?;

--- a/crates/mapi-sys/src/load_mapi.rs
+++ b/crates/mapi-sys/src/load_mapi.rs
@@ -18,10 +18,10 @@ pub const OFFICE_QUALIFIERS: [(crate::installation::Architecture, PCWSTR); 14] =
         w!("outlook.x64.exe"),
     ),
     (crate::installation::Architecture::X86, w!("outlook.exe")),
-    // Excel - most common Office app
+    // Excel
     (crate::installation::Architecture::X64, w!("excel.x64.exe")),
     (crate::installation::Architecture::X86, w!("excel.exe")),
-    // Word - also very common
+    // Word
     (
         crate::installation::Architecture::X64,
         w!("winword.x64.exe"),


### PR DESCRIPTION
### Problem
The existing MAPI detection used Outlook-specific component GUIDs with the Windows Installer API ([MsiProvideQualifiedComponentW](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)). However, recent M365 versions of Office will now include MAPI libraries even when Outlook is not installed. The old Outlook-specific detection method failed to find these MAPI libraries, causing checks to fail when attempting to verify MAPI installation.

### Solution
Added fallback Office app qualifiers for more robust MAPI detection. Adds architecture detection for fallback apps.

### Changes
- Added support for 7 Office apps (both x86/x64): Outlook, Excel, Word, PowerPoint, Access, OneNote, Publisher
- Centralized app qualifiers in OFFICE_QUALIFIERS constant
- Architecture detection for fallback app qualifiers
- Maintains backward compatibility - Outlook detection still works as before

### Results
❌ Before: MAPI initialization failed with Office installations (no Outlook)
✅ After: Successfully detects MAPI in recent Office 16.0+ installation

No breaking changes - fully backward compatible.